### PR TITLE
move localstack-core to dev extra

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ $(VENV_ACTIVATE): setup.py setup.cfg
 	test -d .venv || $(VENV_BIN) .venv
 	$(VENV_RUN); pip install --upgrade pip setuptools plux wheel
 	$(VENV_RUN); pip install --upgrade black isort pyproject-flake8 flake8-black flake8-isort
-	$(VENV_RUN); pip install -e .
+	$(VENV_RUN); pip install -e .[dev]
 	touch $(VENV_DIR)/bin/activate
 
 clean:
@@ -25,10 +25,10 @@ format:            		  ## Run black and isort code formatter
 	$(VENV_RUN); python -m isort .; python -m black .
 
 install: venv
-	$(VENV_RUN); python -m pip install -e .[dev]
+	$(VENV_RUN); python -m plux entrypoints
 
 dist: venv
-	$(VENV_RUN); python setup.py sdist bdist_wheel
+	$(VENV_RUN); python -m build
 
 publish: clean-dist venv dist
 	$(VENV_RUN); pip install --upgrade twine; twine upload dist/*

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ format:            		  ## Run black and isort code formatter
 	$(VENV_RUN); python -m isort .; python -m black .
 
 install: venv
-	$(VENV_RUN); python setup.py develop
+	$(VENV_RUN); python -m pip install -e .[dev]
 
 dist: venv
 	$(VENV_RUN); python setup.py sdist bdist_wheel

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = localstack-extension-platform-observability
-version = 0.0.2
+version = 0.0.3
 summary = LocalStack Extension: LocalStack Extension: Platform observability
 url = https://github.com/localstack/localstack-extension-platform-observability
 author = LocalStack Contributors

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,9 +12,10 @@ long_description_content_type = text/markdown; charset=UTF-8
 [options]
 zip_safe = False
 packages = find:
-install_requires =
-    localstack>=3.5
-    werkzeug
+
+[options.extras_require]
+dev =
+    localstack-core>=3.5
 
 [options.entry_points]
 localstack.extensions =


### PR DESCRIPTION
## Motivation
With https://github.com/localstack/localstack/pull/11190, the `localstack` module is now an implicit namespace module.
However, in the latest release (3.5) this was not yet the case.
This uncovered an issue with the extensions if they define `localstack-core` (either directly or transitively via `localstack-core`) as an install-dependency:
- When installing the extension, the python package install dependencies are also installed into the extension virtual environment.
- When the extension defines an install-dependency on `localstack-core`, it will install the latest release of `localstack-core` into the extension virtual environment.
  - The extension virtual environment is directly linked to the main virtual environment in the LocalStack container and should directly use the code from the image (and not install it as an additional external dependency).
  - However, this currently causes a conflict because the installed version `3.5` - since it's not an implicit namespace package yet - which overwrites the module in the main venv.

Relates to https://github.com/localstack/localstack-extensions/pull/73.